### PR TITLE
Add slash_with_burn API for automated alpha burn after slash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "collateral_sdk"
-version = "1.0.6"
+version = "1.0.7"
 description = ""
 authors = []
 readme = "README.md"

--- a/src/collateral_sdk/collateral.py
+++ b/src/collateral_sdk/collateral.py
@@ -192,7 +192,7 @@ class CollateralManager:
         """
 
         if amount <= 0:
-            raise ValueError("Amount must be greater than zero: {amount}")
+            raise ValueError(f"Amount must be greater than zero: {amount}")
 
         if not is_valid_ss58_address(source_stake):
             raise ValueError(f"Invalid stake address: {source_stake}")
@@ -690,7 +690,7 @@ class CollateralManager:
             raise ValueError(f"Invalid SS58 address: {address}")
 
         if amount <= 0:
-            raise ValueError("Amount must be greater than zero: {amount}")
+            raise ValueError(f"Amount must be greater than zero: {amount}")
 
         amount: Balance = Balance.from_rao(amount, netuid=self.network.netuid)
 
@@ -859,7 +859,7 @@ class CollateralManager:
         """
 
         if amount <= 0:
-            raise ValueError("Amount must be greater than zero: {amount}")
+            raise ValueError(f"Amount must be greater than zero: {amount}")
 
         if not is_valid_ss58_address(source_coldkey):
             raise ValueError(f"Invalid destination SS58 address: {source_coldkey}")

--- a/src/collateral_sdk/collateral.py
+++ b/src/collateral_sdk/collateral.py
@@ -542,7 +542,7 @@ class CollateralManager:
                     {
                         "chainId": self.network.evm_chain_id,
                         "from": owner_address,
-                        "nonce": web3.eth.get_transaction_count(owner_address),  # pyright: ignore[reportArgumentType]
+                        "nonce": web3.eth.get_transaction_count(owner_address, block_identifier="pending"),  # pyright: ignore[reportArgumentType]
                     }
                 )
 
@@ -606,7 +606,7 @@ class CollateralManager:
                     {
                         "chainId": self.network.evm_chain_id,
                         "from": owner_address,
-                        "nonce": web3.eth.get_transaction_count(owner_address),  # pyright: ignore[reportArgumentType]
+                        "nonce": web3.eth.get_transaction_count(owner_address, block_identifier="pending"),  # pyright: ignore[reportArgumentType]
                     }
                 )
 
@@ -706,7 +706,7 @@ class CollateralManager:
                     {
                         "chainId": self.network.evm_chain_id,
                         "from": owner_address,
-                        "nonce": web3.eth.get_transaction_count(owner_address),  # pyright: ignore[reportArgumentType]
+                        "nonce": web3.eth.get_transaction_count(owner_address, block_identifier="pending"),  # pyright: ignore[reportArgumentType]
                     }
                 )
 
@@ -890,7 +890,7 @@ class CollateralManager:
                     {
                         "chainId": self.network.evm_chain_id,
                         "from": owner_address,
-                        "nonce": web3.eth.get_transaction_count(owner_address),  # pyright: ignore[reportArgumentType]
+                        "nonce": web3.eth.get_transaction_count(owner_address, block_identifier="pending"),  # pyright: ignore[reportArgumentType]
                     }
                 )
 

--- a/src/collateral_sdk/collateral.py
+++ b/src/collateral_sdk/collateral.py
@@ -321,8 +321,7 @@ class CollateralManager:
 
         if not (module_name == "SubtensorModule" and function_name == "transfer_stake"):
             raise ValueError(
-                f"Invalid extrinsic: expected 'SubtensorModule.transfer_stake', "
-                f"got '{module_name}.{function_name}'"
+                f"Invalid extrinsic: expected 'SubtensorModule.transfer_stake', got '{module_name}.{function_name}'"
             )
 
         if isinstance(call_args := extrinsic["call"]["call_args"], dict):
@@ -1044,7 +1043,7 @@ class CollateralManager:
 
             except Exception as e:
                 if i < max_retries - 1:
-                    time.sleep(min(2 ** i, max_backoff))
+                    time.sleep(min(2**i, max_backoff))
                     continue
                 else:
                     raise SubtensorError(f"{error_message}: {e}") from e
@@ -1102,7 +1101,7 @@ class CollateralManager:
 
             except Exception as e:
                 if i < max_retries - 1:
-                    time.sleep(min(2 ** i, max_backoff))
+                    time.sleep(min(2**i, max_backoff))
                     continue
                 else:
                     raise EVMError(f"{error_message}: {e}") from e


### PR DESCRIPTION
Adds slash_with_burn API to automatically burn alpha on Subtensor after an EVM slash.
	•	Performs EVM slash → Subtensor burn
	•	Clear error when burn fails after successful slash
	•	Existing slash() behavior remains unchanged

Note: This operation is not atomic. If burn fails, funds remain in the EVM slashedCollateral pool.